### PR TITLE
Fix issue #5 with Model A

### DIFF
--- a/opshin/type_inference.py
+++ b/opshin/type_inference.py
@@ -522,6 +522,14 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
         return None
 
     def type_from_annotation(self, ann: expr):
+        if isinstance(ann, Subscript):
+            value_type = self.type_from_annotation(ann.value)
+            if isinstance(ann.slice, Tuple):
+                slice_types = [self.type_from_annotation(el) for el in ann.slice.elts]
+            else:
+                slice_types = [self.type_from_annotation(ann.slice)]
+            return GenericType(value_type, slice_types)
+
         if isinstance(ann, Constant):
             if ann.value is None:
                 return UnitType()
@@ -538,13 +546,17 @@ class AggressiveTypeInferencer(CompilingNodeTransformer):
             if ann.id in ATOMIC_TYPES:
                 return ATOMIC_TYPES[ann.id]
             if ann.id == "Self":
-                v_t = self.variable_type(ann.idSelf_new)
+                if not self.current_class:
+                    raise TypeInferenceError("'Self' type can only be used within class definitions")
+                return InstanceType(self.current_class)
             elif ann.id in ["Union", "List", "Dict"]:
                 raise TypeInferenceError(
-                    f"Annotation {ann.id} is not allowed as a variable type, use List[Anything], Dict[Anything, Anything] or Union[...] instead"
+                    f"Annotation {ann.id} is not allowed as a bare type, use concrete type arguments like {ann.id}[...]"
                 )
-            else:
+            elif isinstance(ann.ctx, ast.Load):
                 v_t = self.variable_type(ann.id)
+            else:
+                raise TypeInferenceError(f"Unresolved type annotation '{ann.id}'")
             if isinstance(v_t, ClassType):
                 return v_t
             raise TypeInferenceError(


### PR DESCRIPTION
Summary of Changes:
The changes address the `Self` handling in type annotations by:
1. Adding support for generic subscripted types (like `Dict[Self, int]`) by recursively resolving nested types and constructing a `GenericType`.
2. Properly resolving `Self` within class contexts by returning the current class's `InstanceType`, avoiding the `AttributeError` from missing `idSelf`.
3. Improving error messages for bare generics (e.g., `Union` without arguments) to guide users toward correct usage.

These changes directly fix the `AttributeError` caused by `Self` in subscripted types and improve error messaging, resolving both the crash and unhelpful error aspects of the reported issue.

Duration: 4m 39s